### PR TITLE
Don't compile Nitter as root

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -124,6 +124,7 @@ ynh_script_progression --message="Configuring system user..." --weight=1
 
 # Create a system user
 ynh_system_user_create --username=$app
+usermod -d $final_path $app 2>&1
 
 #=================================================
 # SPECIFIC SETUP
@@ -132,10 +133,11 @@ ynh_system_user_create --username=$app
 #=================================================
 ynh_script_progression --message="Compiling Nitter..." --weight=30
 pushd "$final_path" || ynh_die
-	export PATH="$final_path/.nim/bin:$PATH"
-	nimble build -d:release -y
-	nimble scss -y
-	mkdir -p ./tmp
+	chown -R $app:$app $final_path
+	sudo -u $app "PATH=/opt/yunohost/$app/.nim/bin:$(sudo -u $app sh -c 'echo $PATH')" $final_path/.nim/bin/nimble build -d:release -y
+	sudo -u $app "PATH=/opt/yunohost/$app/.nim/bin:$(sudo -u $app sh -c 'echo $PATH')" $final_path/.nim/bin/nimble scss -y
+	mkdir -p $final_path/tmp
+	chown -R root:root $final_path
 popd || ynh_die
 
 #=================================================

--- a/scripts/restore
+++ b/scripts/restore
@@ -63,6 +63,7 @@ ynh_script_progression --message="Recreating the dedicated system user..." --wei
 
 # Create the dedicated user (if not existing)
 ynh_system_user_create --username=$app
+usermod -d $final_path $app 2>&1
 
 #=================================================
 # REINSTALL DEPENDENCIES

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -98,6 +98,7 @@ ynh_script_progression --message="Making sure dedicated system user exists..." -
 
 # Create a dedicated user (if not existing)
 ynh_system_user_create --username=$app
+usermod -d $final_path $app 2>&1
 
 #=================================================
 # SPECIFIC UPGRADE
@@ -106,10 +107,11 @@ ynh_system_user_create --username=$app
 #=================================================
 ynh_script_progression --message="Compiling Nitter..." --weight=30
 pushd "$final_path" || ynh_die
-	export PATH="$final_path/.nim/bin:$PATH"
-	nimble build -d:release -y
-	nimble scss -y
-	mkdir -p ./tmp
+	chown -R $app:$app $final_path
+	sudo -u $app "PATH=/opt/yunohost/$app/.nim/bin:$(sudo -u $app sh -c 'echo $PATH')" $final_path/.nim/bin/nimble build -d:release -y
+	sudo -u $app "PATH=/opt/yunohost/$app/.nim/bin:$(sudo -u $app sh -c 'echo $PATH')" $final_path/.nim/bin/nimble scss -y
+	mkdir -p $final_path/tmp
+	chown -R root:root $final_path
 popd || ynh_die
 
 #=================================================


### PR DESCRIPTION
## Problem
- Compiling nitter as root means running stuff as root that comes from the internet and that we don't want to trust more than we have to

## Solution
- Compile as the `nitter` user instead

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.
